### PR TITLE
Kafka initial setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 services:
+
     laravel.test:
         build:
             context: './vendor/laravel/sail/runtimes/8.4'
@@ -23,7 +24,7 @@ services:
             - sail
         depends_on:
             - mysql
-            - kafka
+
     mysql:
         image: 'mysql/mysql-server:8.0'
         ports:
@@ -48,26 +49,108 @@ services:
                 - '-p${DB_PASSWORD}'
             retries: 3
             timeout: 5s
-    kafka:
+
+    controller-1:
       image: apache/kafka:latest
-      container_name: broker
+      container_name: controller-1
       environment:
         KAFKA_NODE_ID: 1
-        KAFKA_PROCESS_ROLES: broker,controller
-        KAFKA_LISTENERS: PLAINTEXT://localhost:9092,CONTROLLER://localhost:9093
-        KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+        KAFKA_PROCESS_ROLES: controller
+        KAFKA_LISTENERS: CONTROLLER://:9093
+        KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
         KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-        KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-        KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
-        KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1 # increase me when we configure more brokers
-        KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-        KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+        KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
         KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-        KAFKA_NUM_PARTITIONS: 3
+
+    controller-2:
+      image: apache/kafka:latest
+      container_name: controller-2
+      environment:
+        KAFKA_NODE_ID: 2
+        KAFKA_PROCESS_ROLES: controller
+        KAFKA_LISTENERS: CONTROLLER://:9093
+        KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+        KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+        KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
+        KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+
+    controller-3:
+      image: apache/kafka:latest
+      container_name: controller-3
+      environment:
+        KAFKA_NODE_ID: 3
+        KAFKA_PROCESS_ROLES: controller
+        KAFKA_LISTENERS: CONTROLLER://:9093
+        KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+        KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+        KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
+        KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+
+    broker-1:
+      image: apache/kafka:latest
+      container_name: broker-1
+      ports:
+        - 29092:9092
+      environment:
+        KAFKA_NODE_ID: 4
+        KAFKA_PROCESS_ROLES: broker
+        KAFKA_LISTENERS: 'PLAINTEXT://:19092,PLAINTEXT_HOST://:9092'
+        KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://broker-1:19092,PLAINTEXT_HOST://localhost:29092'
+        KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+        KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+        KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+        KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
+        KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      depends_on:
+        - controller-1
+        - controller-2
+        - controller-3
+
+    broker-2:
+      image: apache/kafka:latest
+      container_name: broker-2
+      ports:
+        - 39092:9092
+      environment:
+        KAFKA_NODE_ID: 5
+        KAFKA_PROCESS_ROLES: broker
+        KAFKA_LISTENERS: 'PLAINTEXT://:19092,PLAINTEXT_HOST://:9092'
+        KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://broker-2:19092,PLAINTEXT_HOST://localhost:39092'
+        KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+        KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+        KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+        KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
+        KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      depends_on:
+        - controller-1
+        - controller-2
+        - controller-3
+
+    broker-3:
+      image: apache/kafka:latest
+      container_name: broker-3
+      ports:
+        - 49092:9092
+      environment:
+        KAFKA_NODE_ID: 6
+        KAFKA_PROCESS_ROLES: broker
+        KAFKA_LISTENERS: 'PLAINTEXT://:19092,PLAINTEXT_HOST://:9092'
+        KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://broker-3:19092,PLAINTEXT_HOST://localhost:49092'
+        KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+        KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+        KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+        KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
+        KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      depends_on:
+        - controller-1
+        - controller-2
+        - controller-3
+
 
 networks:
     sail:
         driver: bridge
+
 volumes:
     sail-mysql:
         driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,8 @@ services:
         - controller-1
         - controller-2
         - controller-3
+      volumes:
+          - ./kafka:/kafka
 
     broker-2:
       image: apache/kafka:latest
@@ -125,6 +127,8 @@ services:
         - controller-1
         - controller-2
         - controller-3
+      volumes:
+          - ./kafka:/kafka
 
     broker-3:
       image: apache/kafka:latest
@@ -145,6 +149,8 @@ services:
         - controller-1
         - controller-2
         - controller-3
+      volumes:
+          - ./kafka:/kafka
 
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,6 @@ services:
             - sail
         depends_on:
             - mysql
-            - redis
-            - meilisearch
-            - mailpit
-            - selenium
     mysql:
         image: 'mysql/mysql-server:8.0'
         ports:
@@ -51,55 +47,7 @@ services:
                 - '-p${DB_PASSWORD}'
             retries: 3
             timeout: 5s
-    redis:
-        image: 'redis:alpine'
-        ports:
-            - '${FORWARD_REDIS_PORT:-6379}:6379'
-        volumes:
-            - 'sail-redis:/data'
-        networks:
-            - sail
-        healthcheck:
-            test:
-                - CMD
-                - redis-cli
-                - ping
-            retries: 3
-            timeout: 5s
-    meilisearch:
-        image: 'getmeili/meilisearch:latest'
-        ports:
-            - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
-        environment:
-            MEILI_NO_ANALYTICS: '${MEILISEARCH_NO_ANALYTICS:-false}'
-        volumes:
-            - 'sail-meilisearch:/meili_data'
-        networks:
-            - sail
-        healthcheck:
-            test:
-                - CMD
-                - wget
-                - '--no-verbose'
-                - '--spider'
-                - 'http://127.0.0.1:7700/health'
-            retries: 3
-            timeout: 5s
-    mailpit:
-        image: 'axllent/mailpit:latest'
-        ports:
-            - '${FORWARD_MAILPIT_PORT:-1025}:1025'
-            - '${FORWARD_MAILPIT_DASHBOARD_PORT:-8025}:8025'
-        networks:
-            - sail
-    selenium:
-        image: selenium/standalone-chromium
-        extra_hosts:
-            - 'host.docker.internal:host-gateway'
-        volumes:
-            - '/dev/shm:/dev/shm'
-        networks:
-            - sail
+
 networks:
     sail:
         driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
             - sail
         depends_on:
             - mysql
+            - kafka
     mysql:
         image: 'mysql/mysql-server:8.0'
         ports:
@@ -47,6 +48,22 @@ services:
                 - '-p${DB_PASSWORD}'
             retries: 3
             timeout: 5s
+    kafka:
+      image: apache/kafka:latest
+      container_name: broker
+      environment:
+        KAFKA_NODE_ID: 1
+        KAFKA_PROCESS_ROLES: broker,controller
+        KAFKA_LISTENERS: PLAINTEXT://localhost:9092,CONTROLLER://localhost:9093
+        KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+        KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+        KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+        KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
+        KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1 # increase me when we configure more brokers
+        KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+        KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+        KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+        KAFKA_NUM_PARTITIONS: 3
 
 networks:
     sail:

--- a/kafka/add-events
+++ b/kafka/add-events
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cat /kafka/events \
+    | /opt/kafka/bin/kafka-console-producer.sh \
+          --bootstrap-server broker-1:19092,broker-2:19092,broker-3:19092 \
+          --topic seismic-data

--- a/kafka/add-topic
+++ b/kafka/add-topic
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+/opt/kafka/bin/kafka-topics.sh \
+    --bootstrap-server broker-1:19092,broker-2:19092,broker-3:19092 \
+    --create \
+    --topic seismic-data

--- a/kafka/create-topic
+++ b/kafka/create-topic
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+/opt/kafka/bin/kafka-topics.sh \
+    --bootstrap-server localhost:9092 \
+    --topic seismic-data \
+    --create \
+    --partitions 3 \
+    --replication-factor 1

--- a/kafka/create-topic
+++ b/kafka/create-topic
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-/opt/kafka/bin/kafka-topics.sh \
-    --bootstrap-server localhost:9092 \
-    --topic seismic-data \
-    --create \
-    --partitions 3 \
-    --replication-factor 1

--- a/kafka/demonstrate-kafka-setup
+++ b/kafka/demonstrate-kafka-setup
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+docker exec broker-1 /kafka/add-topic
+docker exec broker-1 /kafka/add-events
+
+sleep 2
+
+docker exec broker-1 /kafka/read-events
+docker exec broker-2 /kafka/read-events
+docker exec broker-3 /kafka/read-events

--- a/kafka/events
+++ b/kafka/events
@@ -1,0 +1,2 @@
+{"id": 1, "latitude": 10, "longitude": 20, "depth": 1, "energy": 42}
+{"id": 2, "latitude": 15, "longitude": 28, "depth": 0.45, "energy": 100000}

--- a/kafka/read-events
+++ b/kafka/read-events
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo HELLO FROM NODE $KAFKA_NODE_ID
+
+/opt/kafka/bin/kafka-console-consumer.sh \
+       --bootstrap-server broker-1:19092,broker-2:19092,broker-3:19092 \
+       --topic seismic-data \
+       --from-beginning \
+       --max-messages 2


### PR DESCRIPTION
This branch contains the proof of concept configuration for Kafka. We set up three controllers and three brokers via docker compose. 

https://hub.docker.com/r/apache/kafka#quick-start


### Usage
1. Check out this branch
2. Run `docker compose up -d` in the project root
3. Wait until all the containers have been running for a few seconds
4. Run `./kafka/demonstrate-kafka-setup` in the project root

### Example output
```
$ ./kafka/demonstrate-kafka-setup 
HELLO FROM 4
{"id":1, "latitude": 10, "longitude": 20, "depth": 1, "energy": 42},
{"id":2, "latitude": 15, "longitude": 28, "depth": 0.45, "energy": 100000}
Processed a total of 2 messages
HELLO FROM 5
{"id":1, "latitude": 10, "longitude": 20, "depth": 1, "energy": 42},
{"id":2, "latitude": 15, "longitude": 28, "depth": 0.45, "energy": 100000}
Processed a total of 2 messages
HELLO FROM 6
{"id":1, "latitude": 10, "longitude": 20, "depth": 1, "energy": 42},
{"id":2, "latitude": 15, "longitude": 28, "depth": 0.45, "energy": 100000}
Processed a total of 2 messages
```